### PR TITLE
Removing the publish step for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,10 +21,5 @@ pipeline {
         archiveArtifacts(artifacts: 'dist/*/*_wppi.zip', onlyIfSuccessful: true)
       }
     }
-    stage('Publish Artifacts to S3') {
-      steps {
-        sh 'echo "Publish to: s3nvcodevit01-assets/artifacts/ccnvjndevenrep07-wppi/$BRANCH_NAME"'
-      }
-    }
   }
 }


### PR DESCRIPTION
The publish step needs to be refined further to be smarter about the bucket being published to. For now, I'm simply removing that step.