### PR TITLE
Add a node statement to linting stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,9 @@ try {
     }
   }
   stage('Publish Linting Results') {
-    checkstyle defaultEncoding: '', healthy: '', pattern: '${WORKSPACE}/phpcs_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
+    node('Master') {
+      checkstyle defaultEncoding: '', healthy: '', pattern: '${WORKSPACE}/phpcs_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
+    }
   }
   stage('Archive Artifacts') {
     node('Master') {


### PR DESCRIPTION
The linting stage was unable to run because it was missing a node
directive to tell it where to run.