### PR TITLE
Test removal of ignore warnings and errors on exit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ try {
   stage('Checking PHP') {
     node('Linux') {
       sh 'echo Path: $PATH'
-      sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
+      sh 'phpcs --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
     }
   }
   stage('Publish Linting Results') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,9 @@ try {
   stage('Checking PHP') {
     node('Linux') {
       sh 'echo Path: $PATH'
-      sh 'phpcs --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=summary --report-file=${WORKSPACE}/phpcs_summary.txt ${WORKSPACE}/dist/*/truedit'
+      sh 'phpcs --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=summary --report-file=${WORKSPACE}/vip_go_phpcs_summary.txt ${WORKSPACE}/dist/*/truedit'
+      sh 'phpcs --standard=WordPressVIPMinimum --report=summary --report-file=${WORKSPACE}/vip_min_phpcs_summary.txt ${WORKSPACE}/dist/*/truedit'
+
     }
   }
   stage('Publish Linting Results') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ try {
   stage('Checking PHP') {
     node('Linux') {
       sh 'echo Path: $PATH'
-      sh 'phpcs --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
+      sh 'phpcs --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=summary --report-file=${WORKSPACE}/phpcs_summary.txt ${WORKSPACE}/dist/*/truedit'
     }
   }
   stage('Publish Linting Results') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,14 +18,13 @@ try {
   stage('Checking PHP') {
     node('Linux') {
       sh 'echo Path: $PATH'
-      sh 'phpcs --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=summary --report-file=${WORKSPACE}/vip_go_phpcs_summary.txt ${WORKSPACE}/dist/*/truedit'
-      sh 'phpcs --standard=WordPressVIPMinimum --report=summary --report-file=${WORKSPACE}/vip_min_phpcs_summary.txt ${WORKSPACE}/dist/*/truedit'
-
+      sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
+      sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/vip_min_phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
     }
   }
   stage('Publish Linting Results') {
     node('Linux') {
-      checkstyle defaultEncoding: '', healthy: '', pattern: 'phpcs_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
+      checkstyle defaultEncoding: '', healthy: '', pattern: '*_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
     }
   }
   stage('Archive Artifacts') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ try {
   stage('Checking PHP') {
     node('Linux') {
       sh 'echo Path: $PATH'
-      sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPress-VIP-Go,WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
+      sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPress-VIP-Go --report=checkstyle --report-file=${WORKSPACE}/phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
       sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/vip_min_phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,13 +23,14 @@ try {
   }
   stage('Publish Linting Results') {
     node('Linux') {
-      //checkstyle defaultEncoding: '', healthy: '', pattern: '*_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
-      def checkstyle = scanForIssues tool: [$class: 'Checkstyle'], pattern: '**_checkstyle.xml'
+      checkstyle defaultEncoding: '', healthy: '', pattern: '*_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
+      /*def checkstyle = scanForIssues tool: [$class: 'Checkstyle'], pattern: '**_checkstyle.xml'
       publishIssues issues:[checkstyle]
-      
+
       publishIssues id:'analysis', name:'PHPCS Results', 
             issues:[checkstyle], 
             filters:[includePackage('io.jenkins.plugins.analysis.*')]
+      */
     }
   }
   stage('Archive Artifacts') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,13 +18,15 @@ try {
   stage('Checking PHP') {
     node('Linux') {
       sh 'echo Path: $PATH'
-      sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPress-VIP-Go --report=checkstyle --report-file=${WORKSPACE}/phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
+      sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPress-VIP-Go --report=checkstyle --report-file=${WORKSPACE}/vip_go_phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
       sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/vip_min_phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
     }
   }
   stage('Publish Linting Results') {
     node('Linux') {
-      checkstyle defaultEncoding: '', healthy: '', pattern: '*_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
+      //checkstyle defaultEncoding: '', healthy: '', pattern: '*_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
+      def checkstyle = scanForIssues tool: [$class: 'Checkstyle'], pattern '**/*_checkstyle.xml'
+      publishIssues issues:[checkstyle]
     }
   }
   stage('Archive Artifacts') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,10 @@ try {
       //checkstyle defaultEncoding: '', healthy: '', pattern: '*_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
       def checkstyle = scanForIssues tool: [$class: 'Checkstyle'], pattern '**/*_checkstyle.xml'
       publishIssues issues:[checkstyle]
+
+      publishIssues id:'analysis', name:'PHPCS Results', 
+            issues:[checkstyle], 
+            filters:[includePackage('io.jenkins.plugins.analysis.*')]
     }
   }
   stage('Archive Artifacts') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ try {
   }
   stage('Checking PHP') {
     node('Linux') {
-      sh 'echo Path: $PATH'
       sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPress-VIP-Go --report=checkstyle --report-file=${WORKSPACE}/vip_go_phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
       sh 'phpcs --runtime-set ignore_warnings_on_exit 1 --runtime-set ignore_errors_on_exit 1 --standard=WordPressVIPMinimum --report=checkstyle --report-file=${WORKSPACE}/vip_min_phpcs_checkstyle.xml ${WORKSPACE}/dist/*/truedit'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,9 @@ try {
   stage('Publish Linting Results') {
     node('Linux') {
       //checkstyle defaultEncoding: '', healthy: '', pattern: '*_checkstyle.xml', unHealthy: '', useStableBuildAsReference: true
-      def checkstyle = scanForIssues tool: [$class: 'Checkstyle'], pattern '**/*_checkstyle.xml'
+      def checkstyle = scanForIssues tool: [$class: 'Checkstyle'], pattern: '**_checkstyle.xml'
       publishIssues issues:[checkstyle]
-
+      
       publishIssues id:'analysis', name:'PHPCS Results', 
             issues:[checkstyle], 
             filters:[includePackage('io.jenkins.plugins.analysis.*')]


### PR DESCRIPTION
It was suggested to us by Liz at WordPress VIP that we try removing the ignore_*_on exit options from our run. I am doing so in an attempt to see the same warnings/errors they're seeing.