### PR TITLE
Add the branch name to the folder structure when uploading phpcs results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ try {
   }
   stage('Publish Artifacts') {
     node('Linux') {
-      s3Upload consoleLogLevel: 'INFO', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 's3nvcodevit02-public/downloads/vipGo', excludedFile: '', flatten: true, gzipFiles: true, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: '*_checkstyle.xml,dist/*/*_wppi.zip', storageClass: 'REDUCED_REDUNDANCY', uploadFromSlave: true, useServerSideEncryption: true]], pluginFailureResultConstraint: 'UNSTABLE', profileName: 'TruEdit S3 Profile', userMetadata: []
+      s3Upload consoleLogLevel: 'INFO', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: "s3nvcodevit02-public/downloads/vipGo/${GIT_BRANCH}", excludedFile: '', flatten: true, gzipFiles: true, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: '*_checkstyle.xml,dist/*/*_wppi.zip', storageClass: 'REDUCED_REDUNDANCY', uploadFromSlave: true, useServerSideEncryption: true]], pluginFailureResultConstraint: 'UNSTABLE', profileName: 'TruEdit S3 Profile', userMetadata: []
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ try {
   }
   stage('Publish Artifacts') {
     node('Linux') {
-      s3Upload consoleLogLevel: 'INFO', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: "s3nvcodevit02-public/downloads/vipGo/${GIT_BRANCH}", excludedFile: '', flatten: true, gzipFiles: true, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: '*_checkstyle.xml,dist/*/*_wppi.zip', storageClass: 'REDUCED_REDUNDANCY', uploadFromSlave: true, useServerSideEncryption: true]], pluginFailureResultConstraint: 'UNSTABLE', profileName: 'TruEdit S3 Profile', userMetadata: []
+      s3Upload consoleLogLevel: 'INFO', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: "s3nvcodevit02-public/downloads/vipGo/${env.BRANCH_NAME}", excludedFile: '', flatten: true, gzipFiles: true, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: '*_checkstyle.xml,dist/*/*_wppi.zip', storageClass: 'REDUCED_REDUNDANCY', uploadFromSlave: true, useServerSideEncryption: true]], pluginFailureResultConstraint: 'UNSTABLE', profileName: 'TruEdit S3 Profile', userMetadata: []
     }
   }
 }


### PR DESCRIPTION
We're clobbering our phpcs results and I'd like to separate them based on branch name.